### PR TITLE
Dodanie skryptu chce_domoticz.sh

### DIFF
--- a/scripts/chce_domoticz.sh
+++ b/scripts/chce_domoticz.sh
@@ -18,13 +18,16 @@ EOF
 )
 #===== Checker =====
 if [ -z "$1" ]; then
-echo "Poprawna składnia: ./chce_domoticz.sh port_http port_https"
+    echo "Poprawna składnia: ./chce_domoticz.sh port_http port_https"
 elif [ -z "$2" ]; then
-echo "Poprawna składnia: ./chce_domoticz.sh port_http port_https"
+    echo "Poprawna składnia: ./chce_domoticz.sh port_http port_https"
 else
+#===== Install required packages =====
+apt update
+apt install libusb-0.1-4 libcurl3-gnutls tar wget lsb -y
 #===== Script =====
 mkdir /opt/domoticz
-cd /opt/domoticz
+cd /opt/domoticz || { echo 'Folder nie istnieje'; exit; }
 wget --inet4-only https://releases.domoticz.com/releases/release/domoticz_linux_x86_64.tgz
 tar -xzvf domoticz_linux_x86_64.tgz
 rm domoticz_linux_x86_64.tgz


### PR DESCRIPTION
1. Pamiętaj o jego uruchomieniu, czyli bash chce_domoticz.sh lub ./chce_domoticz.sh
2. Dodaj sobie dwa nowe porty TCP w panelu i zamieść je w tym skrypcie w sekcji "Variables" - czyli zmienne - ponieważ skrypt je wymaga do działania. Port 1 to port http, bez SSL, zaś drugi https, czyli z SSL.