### PR TITLE
Poprawka dla Wireguard

### DIFF
--- a/scripts/chce_wireguard.sh
+++ b/scripts/chce_wireguard.sh
@@ -5,7 +5,7 @@
 cp /etc/resolv.conf /etc/resolv.back
 
 apt update
-apt install -y --no-install-recommends libmnl-dev make qrencode wireguard-tools resolvconf
+apt install -y --no-install-recommends libmnl-dev make qrencode wireguard-tools resolvconf git iptables
 
 systemctl stop resolvconf
 systemctl disable resolvconf


### PR DESCRIPTION
Debian 11 na Mikrusie nie ma domyślnie zainstalowanych pakietów `iptables` i `git`. Po doinstalowaniu ich skrypt działa bezproblemowo.