### PR TITLE
Fixed test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout generator repository
         uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
       - name: Test modified and new scripts
         run: |
           chmod +x tests/execute_new_and_modified_scripts.sh

--- a/tests/execute_new_and_modified_scripts.sh
+++ b/tests/execute_new_and_modified_scripts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-latest_main_commit=$(git rev-parse refs/remotes/origin/HEAD)
+latest_main_commit=$(git rev-parse "refs/remotes/origin/main")
 current_commit=$(git rev-parse HEAD)
 
 scripts_to_be_tested=$(git diff --no-color --name-only "$latest_main_commit" "$current_commit" | grep --color=never \\.sh$ | grep --color=never ^scripts\\/)


### PR DESCRIPTION
Do tej pory testowy pipeline uruchamiał na sztywno skrypt `chce_LAMP.sh`.
Od teraz uruchamiane są wszystkie nowe i zmodyfikowane skrypty.

Proszę jeszcze o sprawdzenie przez jakiegoś speca od basha :wink:

Fix #112 