### PR TITLE
Better password generator

### DIFF
--- a/actions/chce_usera.sh
+++ b/actions/chce_usera.sh
@@ -39,7 +39,7 @@ _password_get(){
 		# check if password is blank
 		if [ -z "$password" ]; then
 			# generate password
-			password=$(head -c255 /dev/urandom | base64 | grep -Eoi '[a-z0-9]{12}' | head -n1)
+			password=$(apg -M SNCL -m32 | head -1)
 			echo "Twoje hasło to $password"
 			break
 		fi


### PR DESCRIPTION
`Urandom` jest pseudolosowe, a więc w pewnych specyficznych przypadkach może być potencjalnie niebezpieczne podczas 
gdy `apg` służy do generowania haseł, więc teoretycznie powinna być to metoda bezpieczniejsza. 
Osobiście szukałem informacji na ten temat, lecz nie znalazłem jednoznacznego potwierdzenia tej tezy lub jej zaprzeczenia.

Jednak ten zapis jest w mojej opinii seksowniejszy i przy okazji łatwiej jest zmienić regułę generowania hasła. 