### PR TITLE
chce_backup.sh: Poprawka do wykrywania "/storage"

### DIFF
--- a/scripts/chce_backup.sh
+++ b/scripts/chce_backup.sh
@@ -12,7 +12,7 @@ fi
 find_output_dir(){
     if [ -d "/storage/" ]
     then
-        output_directory="/storage/backup"
+        output_dir="/storage/backup"
     else
         if [ -s "/backup_key" ] 
         then


### PR DESCRIPTION
Poprawka do błędu który powodował że backup docelowo lądował w pustej ścieżce "" zamiast do "/storage/backup"