### PR TITLE
Fix dla poprawek konfiguracji w skrypcie chce_jenkins.sh

### DIFF
--- a/scripts/chce_jenkins.sh
+++ b/scripts/chce_jenkins.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Jenkins na mikrusowym porcie 
+# Jenkins na mikrusowym porcie
 # Autor: Maciej Loper, Radoslaw Karasinski
 
 status() {
@@ -25,9 +25,9 @@ echo
 
 status "poprawki w konfiguracji"
 sudo systemctl stop jenkins
-sudo sed -i 's|JENKINS_USER=$NAME|JENKINS_USER=root|' /etc/default/jenkins
-sudo sed -i 's|HTTP_PORT=8080|HTTP_PORT=80|' /etc/default/jenkins
-sudo sed -i 's|JENKINS_USER=$NAME|JENKINS_USER=root|' /etc/default/jenkins
+sed -i 's|User=jenkins|User=root|' /lib/systemd/system/jenkins.service
+sed -i 's|JENKINS_PORT=8080|JENKINS_PORT=80|' /lib/systemd/system/jenkins.service
+sudo systemctl daemon-reload
 echo
 
 status "uruchomienie"


### PR DESCRIPTION
Aktualnie po uruchomieniu skryptu chce Jenkins, aplikacja uruchamia się na domyślnym porcie Jenkinsowym: `8080`:
`usr/bin/java -Djava.awt.headless=true -jar /usr/share/java/jenkins.war --webroot=/var/cache/jenkins/war --httpPort=8080`

Poprawki naprawiają ten błąd, który wynika z tego, że od wersji Jenkinsa 2.332.x  plik `/etc/default/jenkins` nie jest dłużej używany. 