### PR TITLE
Aktualizacja instalacji dockera

### DIFF
--- a/scripts/chce_dockera.sh
+++ b/scripts/chce_dockera.sh
@@ -21,7 +21,7 @@ echo \
 
 apt update
 # Instalacja dockera
-apt install -y docker-ce docker-ce-cli containerd.io docker-compose
+apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Nadanie uprawnień do Dockera dla obecnego non-root usera
 groupadd docker


### PR DESCRIPTION
Aktualizacja instalacji dockera dla zachowania zgodności z oficjalną dokumentacją: https://docs.docker.com/engine/install/ubuntu/

Szczególnie pakiet `docker-compose` to teraz `docker-compose-plugin` i choć stara nazwa nadal działa, nie wiadomo jak długo