### PR TITLE
Always use the latest version of php in chce_LEMP.sh

### DIFF
--- a/scripts/chce_LEMP.sh
+++ b/scripts/chce_LEMP.sh
@@ -11,7 +11,7 @@ fi
 apt update
 apt install -y software-properties-common
 
-# Repozytoria zewnętrzne z PHP 8.0 i najnowszymi wydaniami nginx
+# Repozytoria zewnętrzne z PHP i najnowszymi wydaniami nginx
 add-apt-repository -y ppa:ondrej/php
 add-apt-repository -y ppa:nginx/stable
 
@@ -19,7 +19,7 @@ add-apt-repository -y ppa:nginx/stable
 apt update
 
 # nginx + najpopularniejsze moduły do PHP
-apt install -y nginx php8.0 php8.0-fpm php8.0-zip php8.0-xml php8.0-sqlite3 php8.0-pgsql php8.0-mysql php8.0-mcrypt php8.0-mbstring php8.0-intl php8.0-gd php8.0-curl php8.0-cli php8.0-bcmath
+apt install -y nginx php php-fpm php-zip php-xml php-sqlite3 php-pgsql php-mysql php-mcrypt php-mbstring php-intl php-gd php-curl php-cli php-bcmath
 
 # dodanie MariaDB (klient i serwer)
 apt install -y mariadb-server mariadb-client
@@ -43,7 +43,7 @@ server {
    location ~ \.php\$ {
       include snippets/fastcgi-php.conf;
       
-      fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
+      fastcgi_pass unix:/var/run/php/php-fpm.sock;
    }
 }
 EOF

--- a/scripts/chce_LEMP.sh
+++ b/scripts/chce_LEMP.sh
@@ -58,6 +58,9 @@ echo '<?php echo "2 + 2 = ".(2+2); ' >/var/www/html/index.php
 # Serwer będzie się przedstawiał jako "Nginx" - bez wersji serwera
 sed -e 's/# server_tokens off;/server_tokens off;/' -i /etc/nginx/nginx.conf 
 
+# Dodanie nginxa do autostartu
+systemctl enable --now nginx
+
 # Przeładowanie nginxa
 systemctl reload nginx
 


### PR DESCRIPTION
Wcześniejszy pull request https://github.com/unkn0w/noobs/pull/169 nie uwzględnia php-fpm podczas instalacji, podczas gdy jest wymagany w konfiguracji serwera nginx.