### PR TITLE
chce_LAMP_FastCGI.sh - ustawienie ostatniej dostępnej wersji  #161

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # NOOBS - zestaw skryptów dla początkujących
 
-Skrypty przeznaczone są dla uzytkowników usługi [MIKR.US](https://mikr.us), pracujących w systemie Ubuntu 20.04, jednak większosć z nich powinna działać także poza środowiskiem Mikrusa
+Skrypty przeznaczone są dla uzytkowników usługi [MIKR.US](https://mikr.us), pracujących w systemie Ubuntu 22.04, jednak większosć z nich powinna działać także poza środowiskiem Mikrusa
 
 ## Instalacja
 

--- a/scripts/chce_DOTNET.sh
+++ b/scripts/chce_DOTNET.sh
@@ -3,23 +3,40 @@
 # https://docs.microsoft.com/pl-pl/dotnet/core/install/linux-ubuntu
 #
 
+# określenie wersji systemu
+
+usage (){
+    echo "Uzycie: $0 wersja";
+    echo "Musisz podać wersję do zainstalowania np. 7.0";
+    exit 3;
+}
+
+[ "$#" -lt 1 ] && usage
+
+dotnet_version="$1"
+
+apt-get install -y lsb-release
+
+os-version=$(lsb_release -sr)
+
 # Zainstaluj klucze do podpisywania pakietów microsoft
-wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
-sudo dpkg -i /tmp/packages-microsoft-prod.deb
-rm /tmp/packages-microsoft-prod.deb
+apt-get install -y gpg
+cd /tmp
+wget -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o microsoft.asc.gpg
+mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
+wget https://packages.microsoft.com/config/ubuntu/'$os-version'/prod.list
+mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
+chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 
 # Aktualizacja apt
-sudo apt-get update;
+apt-get update
 
-# Instalacja dotnet-sdk-5.0
-sudo apt-get install -y apt-transport-https && \
-    sudo apt-get update && \
-    sudo apt-get install -y dotnet-sdk-5.0
+# Instalacja dotnet-sdk
+apt-get install -y dotnet-sdk-"$dotnet_version"
 
 # Instalacia środwiska uruchomieniowego platfromy ASP.NET Core
-sudo apt-get install -y apt-transport-https && \
-    sudo apt-get update && \
-    sudo apt-get install -y aspnetcore-runtime-5.0
+apt-get install -y aspnetcore-runtime-"$dotnet_version"
 
 # Lub alternatywa: ASP.NET zmiast ASP.NET Core
-# sudo apt-get install -y dotnet-runtime-5.0
+# sudo apt-get install -y dotnet-runtime-"$dotnet_version"

--- a/scripts/chce_LAMP_FastCGI.sh
+++ b/scripts/chce_LAMP_FastCGI.sh
@@ -4,14 +4,14 @@
 # Edited and modified by: Andrzej 'Ferex' Szczepaniak & Jarosław 'Evilus' Rauza
 
 apt update
-apt install -y software-properties-common 
+apt install -y software-properties-common
 
-# Repozytoria zewnętrzne z PHP 8.0 i najnowszym Apachem (nie ma ich w standardowym Ubuntu)
+# Repozytoria zewnętrzne z PHP i najnowszym Apachem (nie ma ich w standardowym Ubuntu)
 add-apt-repository -y ppa:ondrej/apache2
 add-apt-repository -y ppa:ondrej/php
 
 # apache + najpopularniejsze moduły do PHP oraz memcached
-apt install -y apache2 libapache2-mod-fcgid php8.0 php8.0-fpm php8.0-memcached php8.0-memcache php8.0-zip php8.0-xml php8.0-sqlite3 php8.0-pgsql php8.0-mysql php8.0-mcrypt php8.0-mbstring php8.0-intl php8.0-gd php8.0-curl php8.0-cli php8.0-bcmath
+apt install -y apache2 libapache2-mod-fcgid php php-fpm php-memcached php-memcache php-zip php-xml php-sqlite3 php-pgsql php-mysql php-mcrypt php-mbstring php-intl php-gd php-curl php-cli php-bcmath
 
 # zmiana mpm_prefork na mpm_event, mpm-prefork działa kiedy instalujemy libapache2-mod-php, zaś event dla php-fpm
 a2dismod mpm_prefork
@@ -23,11 +23,12 @@ a2enmod rewrite setenvif proxy proxy_fcgi
 # instalacja memcached
 apt install memcached libmemcached-tools -y
 
-# aktywacja konfiguracji modułu php8.0-fpm dla apache2
-a2enconf php8.0-fpm
+# aktywacja konfiguracji modułu php-fpm dla apache2
+phpversion=$(/usr/bin/php.default -v | head -1 | cut -c5-7)
+a2enconf php"$phpversion"-fpm
 
 # restart usługi po dodaniu nowego modułu
-systemctl restart apache2
+apache2ctl restart
 
 # dodanie MariaDB (klient i serwer)
 apt install -y mariadb-server mariadb-client
@@ -39,7 +40,7 @@ systemctl start mariadb
 systemctl enable apache2
 systemctl enable mariadb
 
-# Usuwamy domyślną 
+# Usuwamy domyślną
 rm /var/www/html/index.html
 
 # Dowód na działanie PHP


### PR DESCRIPTION
W oparciu o metapakiet php-cli dodałem wyciąganie ostatniej domyślnej wersji i ustawienie jej jako docelowa w apache.