### PR TITLE
Włączenie dual-stack w skrypcie używanym do stawania k3s

### DIFF
--- a/scripts/chce_k3s.sh
+++ b/scripts/chce_k3s.sh
@@ -19,6 +19,8 @@ cp "$SERVICE_FILE" "${SERVICE_FILE}.bak"
 # dodanie poprawki do pliku
 sed -i '$d' "$SERVICE_FILE"
 cat <<EOF >>"$SERVICE_FILE"
+    --cluster-cidr=10.42.0.0/16,2001:cafe:42:0::/56 \\
+    --service-cidr=10.43.0.0/16,2001:cafe:42:1::/112 \\
     --kubelet-arg=feature-gates=KubeletInUserNamespace=true \\
     --kube-controller-manager-arg=feature-gates=KubeletInUserNamespace=true \\
     --kube-apiserver-arg=feature-gates=KubeletInUserNamespace=true \\


### PR DESCRIPTION
# Opis zmiany

Konfiguracja k3s w trybie dual-stack

# Dlaczego

Standardowo k3s instalowany oficjalną metodą używa tylko i wyłącznie stacku ipv4. Jako, że mikrus nie zapewnia zewnętrznego adresu ipv4 powoduje to problemy przy używaniu ingressa.
Standardowo ingress używa traefika, który słucha tylko i wyłącznie na interfejsie ipv4 i nie jest dostępny na ipv6. Gdy dodamy w cloudflare rekord AAAA oraz włączymy proxy to nie będziemy mogli dostać się do ingress kontolera i strona nie będzie działała.
Poprawka powoduje włączenie ipv6 przez co ingress kontroler słucha na ipv6 i wszyscy są szcęśliwi.

Przykład:
```
root@r169:~# kubectl get ingress
NAME              CLASS     HOSTS   ADDRESS                                 PORTS   AGE
minimal-ingress   traefik   *       192.168.1.169,2a01:4dzz9:3151:1b46::169   80      109s
```
