### PR TITLE
chce_dockera.sh - napraw działanie na debianie

### DIFF
--- a/scripts/chce_dockera.sh
+++ b/scripts/chce_dockera.sh
@@ -16,7 +16,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/
 
 # Dodanie oficjalnych repozytorium Dockera do systmeu
 echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 apt update


### PR DESCRIPTION
Skrypt wywalał się na debianie, bo próbował pobrać dockera z /ubuntu, a w tym katalogu brak jest podfolderów dla nazw kodowych debiana. Teraz w ubuntu będzie pobiearać z /ubuntu, a w debianie z /debian

Mój serwer: e149