### PR TITLE
install ipset in chce_firewall.sh

### DIFF
--- a/scripts/chce_firewall.sh
+++ b/scripts/chce_firewall.sh
@@ -6,7 +6,7 @@
 #
 
 sudo apt update
-sudo apt install ufw
+sudo apt install ufw ipset
 
 sudo ufw default deny incoming
 sudo ufw default allow outgoing


### PR DESCRIPTION
W domyślnym obrazie nie ma pakietu ipset przez co skrypt kończy się niepowodzeniem - wystarczy go zainstalować.