### PR TITLE
Zrefaktoryzowano chce_firewall.sh oraz naprawiono błędy

### DIFF
--- a/scripts/chce_firewall.sh
+++ b/scripts/chce_firewall.sh
@@ -1,52 +1,85 @@
 #!/bin/bash
 #
 # firewall
-# Authors: Kacper Adamczak
-# Version: 1.0
-#
+# Wersja: 1.1
+# Autorzy: Kacper Adamczak, Mariusz Gumienny
 
-sudo apt update
-sudo apt install ufw
+# Skrypt do konfiguracji firewalla UFW.
 
+# Użycie:
+#   sudo ~/noobs/scripts/chce_firewall.sh [port1] [port2] ...
+
+
+echo "Aktualizowanie listy pakietów..."
+sudo apt-get update
+
+echo "Instalowanie wymaganych pakietów (ufw, ipset)..."
+sudo apt-get install -y ufw ipset
+
+add_port() {
+    local port_to_add=$1
+    if sudo ufw allow "$port_to_add"; then
+        echo "✅ Do reguł firewalla poprawnie dodano port $port_to_add"
+    else
+        echo "❌ Błąd dodawania portu $port_to_add do reguł firewalla."
+    fi
+}
+
+echo "Konfigurowanie domyślnych polityk UFW..."
 sudo ufw default deny incoming
 sudo ufw default allow outgoing
 
-sudo ufw allow OpenSSH;
-sudo ufw allow ssh;
+echo "Dodawanie standardowych reguł..."
+add_port "OpenSSH"
+add_port "ssh"
 
-host=$(hostname)
-host=${host:1}
+host_num="$(hostname)"
+host_num="${host_num##*[!0-9]}" # Wyciąga sam numer z nazwy hosta (np. zygfryd123 -> 123)
 
-port1=$((10000+host))
-port2=$((20000+host))
-port3=$((30000+host))
+if [[ -n "$host_num" ]]; then
+    port1=$((10000 + host_num))
+    port2=$((20000 + host_num))
+    port3=$((30000 + host_num))
 
-if sudo ufw allow $port1 ; then
-    echo "Do regul firewalla poprawnie dodano port $port1"
+    echo "Dodawanie standardowych portów Mikrus (host $host_num)..."
+    add_port "$port1"
+    add_port "$port2"
+    add_port "$port3"
 else
-    echo "Blad dodawania $port1 do regul firewalla"
+    echo "⚠️  Ostrzeżenie: Nie udało się automatycznie ustalić numeru hosta. Pomijam dodawanie portów Mikrus."
 fi
 
-if sudo ufw allow $port2 ; then
-    echo "Do regul firewalla poprawnie dodano port $port2"
-else
-    echo "Blad dodawania $port2 do regul firewalla"
+if [ "$#" -gt 0 ]; then
+    echo "Dodawanie dodatkowych portów z linii poleceń..."
+    for extra_port in "$@"; do
+        if [[ "$extra_port" =~ ^[0-9]+$ ]] && (( extra_port >= 1 && extra_port <= 65535 )); then
+            add_port "$extra_port"
+        else
+            echo "⚠️  Ostrzeżenie: Argument '$extra_port' nie jest poprawnym numerem portu (1-65535) i został zignorowany."
+        fi
+    done
 fi
 
-if sudo ufw allow $port3 ; then
-    echo "Do regul firewalla poprawnie dodano port $port3"
-else
-    echo "Blad dodawania $port3 do regul firewalla"
-fi
+echo "Finalizowanie konfiguracji..."
 
 sudo ufw enable
 
-echo "Firewall został włączony"
+echo "✅ Firewall został włączony."
 
-ipset create port_scanners hash:ip family inet hashsize 32768 maxelem 65536 timeout 600
-ipset create scanned_ports hash:ip,port family inet hashsize 32768 maxelem 65536 timeout 60
+echo "Konfigurowanie ipset do ochrony przed skanowaniem portów..."
+sudo ipset destroy port_scanners &>/dev/null
+sudo ipset destroy scanned_ports &>/dev/null
+sudo ipset create port_scanners hash:ip family inet hashsize 32768 maxelem 65536 timeout 600
+sudo ipset create scanned_ports hash:ip,port family inet hashsize 32768 maxelem 65536 timeout 60
 
-iptables -A INPUT -m state --state INVALID -j DROP
-iptables -A INPUT -m state --state NEW -m set ! --match-set scanned_ports src,dst -m hashlimit --hashlimit-above 1/hour --hashlimit-burst 5 --hashlimit-mode srcip --hashlimit-name portscan --hashlimit-htable-expire 10000 -j SET --add-set port_scanners src --exist
-iptables -A INPUT -m state --state NEW -m set --match-set port_scanners src -j DROP
-iptables -A INPUT -m state --state NEW -j SET --add-set scanned_ports src,dst
+if ! sudo iptables -C INPUT -m state --state INVALID -j DROP &>/dev/null; then
+    sudo iptables -A INPUT -m state --state INVALID -j DROP
+    sudo iptables -A INPUT -m state --state NEW -m set ! --match-set scanned_ports src,dst -m hashlimit --hashlimit-above 1/hour --hashlimit-burst 5 --hashlimit-mode srcip --hashlimit-name portscan --hashlimit-htable-expire 10000 -j SET --add-set port_scanners src --exist
+    sudo iptables -A INPUT -m state --state NEW -m set --match-set port_scanners src -j DROP
+    sudo iptables -A INPUT -m state --state NEW -j SET --add-set scanned_ports src,dst
+    echo "✅ Dodano reguły iptables do ochrony przed skanowaniem."
+else
+    echo "ℹ️  Reguły iptables do ochrony przed skanowaniem już istnieją."
+fi
+
+echo "Konfiguracja firewalla zakończona."


### PR DESCRIPTION
Przeprowadziłem refaktoryzację i poprawiłem kilka błędów:
- **funkcja add_port()**: jednolite dodawanie portów z komunikatami ✅/❌.
- **host**: ekstrakcja numeru hosta z nazwy (działa dla nowych nazw hostów); jeśli brak liczby – ostrzeżenie i pominięcie.
- **dodatkowe porty**: argumenty CLI 1–65535; nieprawidłowe ignorowane z ostrzeżeniem.
- **ipset & iptables**: niszczenie starych zestawów, tworzenie nowych, sprawdzanie przed dodaniem reguł, komunikaty o stanie.