### PR TITLE
Poprawki w chce_git_status_SP1. Zamyka #201.

### DIFF
--- a/actions/chce_git_status_PS1.sh
+++ b/actions/chce_git_status_PS1.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Dodanie do aktualnego $PS1 statusu repozytorium gita bieżącego katalogu
-# Autor: Tomasz Wiśniewski
+# Autor: Tomasz Wiśniewski, krystofair @ 2025-09-22
+
+echo "Jeśli twoja wybrana powłoka nie zadziała, to spróbuj zainstalować do 'bash'."
+sleep 1
 
 if ! shopt -oq posix; then
     if [ -f /usr/share/bash-completion/bash_completion ]; then
@@ -10,28 +13,204 @@ if ! shopt -oq posix; then
     fi
 fi
 
-ALL_FUNCTIONS="$(declare -F)"
+GIT_PROMPT_FILE=/tmp/git-prompt.sh
 
-if [[ "$ALL_FUNCTIONS" == *"__git_ps1"* ]]; then
-    echo "Funkcja __git_ps1 jest rozpoznawana"
-else
+# 1. Parametr - wybrana powłoka
+# 2. Parametr - wybrany sposób instalacji
+# Zmianna 'ipath' przechowuje zwracaną wartość
+get_install_path_for_specific_shell() {
+  if [[ $2 == system ]]; then
+    case $1 in
+      bash) ipath=/etc/profile.d/git-ps1.sh ;;
+      csh) ipath=/etc/csh.cshrc ;;
+      zsh) ipath=/etc/zsh/zshrc.d/git-ps1.zsh ;;
+    esac
+  elif [[ $2 == user ]]; then
+    case $1 in
+      bash) ipath=$HOME/.bashrc ;;
+      csh) ipath=$HOME/.cshrc ;;
+      zsh) ipath=$HOME/.zshrc ;;
+    esac
+  fi
+
+  if test -n "$ipath"
+  then
+    echo $ipath
+    return 0
+  fi
+  return 1;
+}
+
+# Miejsce instalacji - katalog domowy użytkownika lub /etc/.profile = system wide.
+# Jeśli użytkownik wykonujący skrypt ma UID 0 - jest root'em to opcja jest domyślnie
+# dla wszystkich ponieważ ma on odpowiednie uprawnienia. W pozostałych przypadkach
+# instalacja będzie w /home/$USER.
+choose_installation_place() {
+  all_user_install_hint="y/N"
+  def_val=n
+  if test $UID = 0; then
+    all_user_install_hint="Y/n";
+    def_val=y
+  fi
+  read -p "Czy zainstalować dla wszystkich użytkowników? ${all_user_install_hint}: " \
+  all_user_install
+  case ${all_user_install:-$def_val} in
+    y|Y|1|yes) install_place='system';;
+    n|N|0|no) install_place='user';;
+    *)
+        if test -n "$(echo $install_place_hint | grep -o Y)"
+        then install_place='system'
+        else install_place='user'
+        fi
+      ;;
+  esac
+  unset def_val
+  unset all_user_install_hint
+  unset all_user_install
+
+  echo $install_place
+  unset install_place
+  return 0
+}
+
+# XXX: Przeczytaj plik z repozytorium gita,
+#      jeśli chcesz dodać jeszcze jakieś funkcjonalności.
+choose_features() {
+  read -p "Czy wyświetlać stan kiedy występuje konflikt podczas 'merge'u itp? y/N: " r
+  if test -n "$(echo $r | grep -i y)"; then
+    echo "export GIT_PS1_SHOWCONFLICTSTATE=$r;"
+  fi
+  unset r
+
+  read -p "Czy wyświetlać tzw dirty state (pliki zmodyfikowane itp)? Y/n: " r
+  if test -n "$(echo ${r:-y} | grep -i y)"; then
+    echo "export GIT_PS1_SHOWDIRTYSTATE=${r:-y};"
+  fi
+  unset r
+
+  read -p "Czy wyświetlać symbol \$ kiedy są pliki w 'git stash'? y/N: " r
+  if test -n "$(echo $r | grep -i y)"; then
+    echo "export GIT_PS1_SHOWSTASHSTATE=$r;"
+  fi
+  unset r
+
+  read -p "Czy ukrywać status kiedy folder jest ignorowany przez GITa? Y/n: " r
+  if test -n "$(echo ${r:-y} | grep -i y)"; then
+    echo "export GIT_PS1_HIDE_IF_PWD_IGNORED=${r:-y};"
+  fi
+  unset r
+
+  read -p "Czy chcesz, aby status wyświetlał się w różnym kolorze w zależności od stanu? Y/n: " r
+  if test -n "$(echo ${r:-y} | grep -i y)"; then
+    echo "export GIT_PS1_SHOWCOLORHINTS=${r:-y};"
+  fi
+  unset r
+
+  return 0
+}
+
+# Wypisuje powłoki z pliku /etc/shells - tam są trzymane wszystkie dostępne.
+# Grepem wykluczam komentarze - linie rozpoczęte od '#'.
+# Odwracam, aby w łatwy sposób wyciągnąć nazwy powłok, wycinam i biorę pierwsze pole.
+# Przywracam tekst z lewej do prawej i sortuję ponieważ inaczej 'uniq' nie zadziała.
+# Na końcu używam xargs, który tworzy ciąg nazw podzielonych spacją.
+# Wszystko jest wczytane do tablicy "accessible_shells".
+choose_shell() {
+    all_shells=$(cat /etc/shells \
+    | grep -Ev '^#' \
+    | rev | tr -s ' ' | cut -d'/' -f1 \
+    | rev | sort | uniq \
+    | xargs | tr ' ' ','
+  )
+
+  def_sh=$(echo $SHELL | rev | cut -d'/' -f1 | rev)
+  read -p "Wybierz powłokę[$def_sh] spośród $all_shells: " chosen_shell
+  unset all_shells
+  unset def_sh
+  if test -z "$chosen_shell"; then chosen_shell='bash'; fi
+  # Sprawdzenie obsługiwanych powłok.
+  case $chosen_shell in
+    sh|bash) chosen_shell='bash';;
+    # tcsh) chosen_shell='csh';; XXX: tcsh ma inny plik ~/.tcshrc, ale system-wide wiem
+    csh) chosen_shell='csh';;
+    zsh) : ;;
+    *)
+      echo "Wybrana powłoka jest nieobsługiwana, przepraszamy."
+      unset chosen_shell
+      return -1
+    ;;
+  esac
+  echo $chosen_shell
+  unset chosen_shell
+  return 0
+}
+
+ch_shell=$(choose_shell)
+if [[ ! $? -eq 0 ]]; then echo $ch_shell; exit -1; fi
+
+installation_type=$(choose_installation_place)
+install_path=$(get_install_path_for_specific_shell $ch_shell $installation_type)
+if [[ ! $? -eq 0 ]]; then echo "Coś poszło nie tak."; exit -1; fi
+
+
+if [[ ! -e $GIT_PROMPT_FILE ]]
+then
     # https://anotheruiguy.gitbooks.io/gitforeveryone/content/auto/README.html
     GIT_PROMPT_FILE_URL="https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh"
     echo "Pobieram plik $GIT_PROMPT_FILE_URL"
-    curl -o ~/.git-prompt.sh "$GIT_PROMPT_FILE_URL"
-    echo 'source ~/.git-prompt.sh' >>~/.bashrc
+    curl -o $GIT_PROMPT_FILE "$GIT_PROMPT_FILE_URL"
 fi
 
-TRIMMED_DOLLAR_SIGN_PS1="${PS1/\\$/}"
-TRIMMED_PS1="${TRIMMED_DOLLAR_SIGN_PS1%%*( )}"
+features="$(choose_features)"
 
-if [[ "$TRIMMED_PS1" == *"__git_ps1"* ]]; then
-    echo "Prawdopodobnie masz już ustawione docelowe \$PS1"
-    return
+if [[ -e $(dirname $install_path)/git-prompt.sh ]]; then
+  rm $(dirname $install_path)/git-prompt.sh
 fi
 
-GIT_PART='$([[ -z $(git status -s 2>/dev/null) ]] && echo "\[\e[32m\]" || echo "\[\e[31m\]")$(__git_ps1 "(%s)")\[\e[00m\]\$ '
-PS1="$TRIMMED_PS1$GIT_PART"
-echo "Ustawię \$PS1 na $PS1"
-echo "export PS1='$PS1'" >>~/.bashrc
-echo "Dodano pomyślnie"
+if [[ $installation_type == system ]]; then FILENAME=git-prompt.sh
+else FILENAME=.git-prompt.sh
+fi
+
+# W tym miejscu nie ma sprawdzenia czy plik już istnieje,
+# ze względu na to, że jeżeli użytkownik namiesza w oryginalnym pliku,
+# to uruchomienie skryptu po raz drugi naprawi mu ten plik.
+echo "Instaluję plik $FILENAME w katalogu $(dirname $install_path)"
+install -m 0644 $GIT_PROMPT_FILE $(dirname $install_path)/$FILENAME
+
+if test -e $install_path && test -n "$(cat $install_path | grep __git_ps1)"
+then
+  echo "Masz to już zainstalowane dla takich wyborów."
+  unset ch_shell
+  unset installation_type
+  unset install_path
+  exit 0
+fi
+
+echo "Dodaję nowe instrukcje do pliku $install_path"
+echo "# === Dodane przez skrypt 'chce_git_status_PS1.sh'. ===" >> $install_path
+echo "$features" >> $install_path
+echo 'if [[ -z $(declare -F | grep __git_ps1) ]]; then' >> $install_path
+echo "source $(dirname $install_path)/$FILENAME" >> $install_path
+echo 'fi' >> $install_path
+case $ch_shell in
+  bash|csh)
+    echo $'export PS1=\'$(__git_ps1 \(%s%s\))[\u@\h \w]\n\$ \'' >> $install_path
+  ;;
+  zsh)
+    echo $'setopt PROMPT_SUBST; PS1=\'[%n@%m %c$(__git_ps1 \" (%s)\")]\$ \'' >> $install_path
+  ;;
+esac
+echo "# =====================================================" >> $install_path
+
+# not going to work
+# source $install_path  # apply immediately
+
+unset install_path
+unset ch_shell
+unset installation_type
+unset features
+unset FILENAME
+rm -f $GIT_PROMPT_FILE
+
+exit 0
+


### PR DESCRIPTION
* Poprawka do wyświetlania pełnego PS1.
* Wykorzystanie wielu feature'ów z pliku z funkcjonalnością. Interaktywne odpytywanie co dodać i chyba sensowne domyślne wybory.
* Nie ma koloryzacji która była robiona ręcznie. Teraz jest przez użycie funkcjonalności z `__git_ps1`
* Wybór powłoki do której dodać funkcjonalność, domyślna wartość ze zmiennej \$SHELL, oraz wypis zainstalowanych powłok z /etc/shells. [słabo przetestowane]

Dobrze przetestowane dla basha - możliwość instalacji system-wide (domyślne kiedy instalacja przez roota) i dla użytkownika - domyślnie w przeciwnym wypadku.
Ogólnie korzysta z `/etc/profile.d/` dla instalacji dla wszystkich, a widziałem że `zsh` emuluje zachowanie basha i też `source'uje` te skrypty. Na początku jest info, że warto próbować 'bash'em lecieć kiedy coś nie zadziała.
