### PR TITLE
Add possibility to get config variable values from params in chce_fail2ban.sh

### DIFF
--- a/scripts/chce_fail2ban.sh
+++ b/scripts/chce_fail2ban.sh
@@ -8,16 +8,34 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-# Zmienne konfiguracyjne
+# Domyslne zmienne konfiguracyjne
 BAN_TIME=30m
 FIND_TIME=3m
 MAXRETRY=5
 SSH_PORT=
 
-if [[ $SSH_PORT == "" ]]; then
-   echo -e "Otworz skrypt i ustaw swoj port ssh ktorego uzywasz do polaczenia z mikrusem"
-   exit
-fi
+usage() {
+   echo "Uzycie: sudo $0 -p SSH_PORT [-b BAN_TIME] [-f FIND_TIME] [-m MAXRETRY]"
+   echo ""
+   echo "  -p PORT    Port SSH (wymagany)"
+   echo "  -b TIME    Czas bana (domyslnie: 30m)"
+   echo "  -f TIME    Czas okna monitorowania (domyslnie: 3m)"
+   echo "  -m NUM     Maksymalna liczba prob (domyslnie: 5)"
+   echo ""
+   echo "Przyklad: sudo $0 -p 2222 -b 1h -f 5m -m 3"
+   exit 1
+}
+
+while getopts "p:b:f:m:h" opt; do
+   case $opt in
+      p) SSH_PORT="$OPTARG" ;;
+      b) BAN_TIME="$OPTARG" ;;
+      f) FIND_TIME="$OPTARG" ;;
+      m) MAXRETRY="$OPTARG" ;;
+      h) usage ;;
+      *) usage ;;
+   esac
+done
 
 apt update
 apt install -y fail2ban
@@ -25,7 +43,7 @@ apt install -y fail2ban
 # Zatrzymaj usluge fail2ban
 systemctl stop fail2ban
 
-# Lokalny plik z konfiguracyjny
+# Lokalny plik konfiguracyjny
 config=$(cat <<EOF
 [DEFAULT]
 ignoreip = 127.0.0.1
@@ -45,3 +63,5 @@ echo "$config" >> /etc/fail2ban/jail.local
 
 # Uruchomienie uslugi
 systemctl enable --now fail2ban
+
+echo -e "\033[1;32mFail2ban zainstalowany i uruchomiony!\033[0m"

--- a/scripts/chce_fail2ban.sh
+++ b/scripts/chce_fail2ban.sh
@@ -38,6 +38,12 @@ while getopts "p:b:f:m:h" opt; do
    esac
 done
 
+if [[ -z "$SSH_PORT" ]]; then
+   echo -e "\033[1;31mBlad:\033[0m Nie podano portu SSH. Uzyj flagi -p PORT."
+   echo ""
+   usage
+fi
+
 apt update
 apt install -y fail2ban
 

--- a/scripts/chce_fail2ban.sh
+++ b/scripts/chce_fail2ban.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # fail2ban
 # Autor: Bartlomiej Szyszko
+# Edycja: ThomasMaven
 
 # Sprawdz uprawnienia przed wykonaniem skryptu instalacyjnego
 if [[ $EUID -ne 0 ]]; then


### PR DESCRIPTION
Zaimplementowałem sugestię z https://github.com/unkn0w/noobs/issues/202
Teraz wartości zmiennych konfiguracyjnych można podać jako parametr bez konieczności edycji skryptu przed użyciem.