### PR TITLE
Fix to chce_wireguard.sh wireguard's port being set to 200

### DIFF
--- a/scripts/chce_wireguard.sh
+++ b/scripts/chce_wireguard.sh
@@ -97,7 +97,7 @@ wg pubkey < /etc/wireguard/privatekey > /etc/wireguard/publickey
 wg pubkey < /etc/wireguard/client-privatekey > /etc/wireguard/client-publickey
 
 # Generate server configuration using a generator script
-srv=$(hostname)
+srv=$(hostname | sed -E 's/^([a-z])[a-z]+([0-9]+)$/\1\2/')
 privkey=$(cat /etc/wireguard/privatekey)
 pubkey=$(cat /etc/wireguard/publickey)
 cliprivkey=$(cat /etc/wireguard/client-privatekey)

--- a/scripts/chce_wireguard.sh
+++ b/scripts/chce_wireguard.sh
@@ -3,6 +3,7 @@
 # Współautor: Jakub 'unknow' Mrugalski
 # Aktualizacja: Dawid Kasza
 # Aktualizacja2: Michał Skórcz
+# Aktualizacja3: Karol Adameczek
 set -e
 
 # Sprawdz uprawnienia przed wykonaniem skryptu instalacyjnego


### PR DESCRIPTION
"https://mikr.us/generator.php" expects server name in old format (e.g. j123) instead of current format (e.g. julia123). When name in new format (e.g. julia123) is provided, then returned config has port set to 200 (instead of correct 20123 for this sample host). Adding this sed to extract first letter and tailing number from hostname and combining them fixes this issue.

One question that came to my mind is if generator endpoint should be used at all? Maybe it should be abandoned in favour of creating config file directly in the script.

If there is a better way to implement this, please let me know. I'm no shell master and that's my first github contribution. :)