### PR TITLE
Dodanie komend do instalacji, backupu i aktualizacji Baserow

### DIFF
--- a/default-tools/baserow_backup
+++ b/default-tools/baserow_backup
@@ -17,6 +17,11 @@ CONFIG_DIR="/root/.baserow"
 CONFIG_FILE="${CONFIG_DIR}/mikrus.cfg"
 CRON_FILE="/etc/cron.d/baserow_backuper"
 
+# Ścieżka do samego siebie. Wpis crona musi wskazywać realną lokalizację
+# skryptu, a nie zakładać /bin - narzędzie uruchomione z checkoutu repozytorium
+# ustawiało crona na nieistniejący plik i backup cicho nie działał.
+SELF_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+
 print_error() {
     echo -e "${RED}❌ $1${NC}"
 }
@@ -75,7 +80,7 @@ fi
 if [ "$1" != "RUN" ]; then
     randomMinute=$((RANDOM % 60))
     print_action "Konfiguruję automatyczny backup (godzina 4:${randomMinute})"
-    echo "${randomMinute} 4 * * * root /bin/baserow_backup RUN >/dev/null 2>&1" > "${CRON_FILE}"
+    echo "${randomMinute} 4 * * * root ${SELF_PATH} RUN >/dev/null 2>&1" > "${CRON_FILE}"
     print_success "Automatyczny skrypt backupu został aktywowany"
     print_info "Backupy trafią do: ${BACKUP_DIR}/"
     exit 0

--- a/default-tools/baserow_backup
+++ b/default-tools/baserow_backup
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Skrypt tworzy backup Baserow w środowisku Mikrusowym
+
+# ile ostatnich backupów trzymać?
+LASTBACKUPS=7
+
+# Kolory
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+NC='\033[0m'
+
+CONFIG_DIR="/root/.baserow"
+BACKUP_DIR="/backup/baserow"
+CRON_FILE="/etc/cron.d/baserow_backuper"
+
+print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+print_action() {
+    echo -e "${YELLOW}🔧 $1${NC}"
+}
+
+print_info() {
+    echo -e "$1"
+}
+
+if [ ! -d "${CONFIG_DIR}" ]; then
+    print_error "Nie widzę zainstalowanego Baserow → użyj: baserow_install"
+    exit 1
+fi
+
+if [ ! -d "${BACKUP_DIR}" ]; then
+    print_action "Tworzę katalog ${BACKUP_DIR}/"
+    mkdir -p "${BACKUP_DIR}"
+fi
+
+if [ "$1" != "RUN" ]; then
+    randomMinute=$((RANDOM % 60))
+    print_action "Konfiguruję automatyczny backup (godzina 4:${randomMinute})"
+    echo "${randomMinute} 4 * * * root /bin/baserow_backup RUN >/dev/null 2>&1" > "${CRON_FILE}"
+    print_success "Automatyczny skrypt backupu został aktywowany"
+    exit 0
+fi
+
+find "${BACKUP_DIR}/" -name "*.tar.gz" -type f -mtime +${LASTBACKUPS} -delete
+
+currentDate=$(date +%Y%m%d)
+archivePath="${BACKUP_DIR}/${currentDate}_baserow.tar.gz"
+wasRunning=0
+
+print_info "Rozpoczynam backup Baserow..."
+print_info "Data backupu: ${currentDate}"
+
+if docker ps --format '{{.Names}}' | grep -q '^baserow$'; then
+    wasRunning=1
+    print_action "Zatrzymuję kontener baserow na czas backupu"
+    docker stop baserow >/dev/null
+fi
+
+print_action "Tworzę archiwum ${archivePath}"
+if tar -czf "${archivePath}" -C /root .baserow; then
+    print_success "Backup Baserow został utworzony: ${archivePath}"
+else
+    print_error "Nie udało się utworzyć backupu Baserow"
+    if [ "${wasRunning}" -eq 1 ]; then
+        print_action "Przywracam działanie kontenera baserow po błędzie backupu"
+        docker start baserow >/dev/null
+    fi
+    exit 1
+fi
+
+if [ "${wasRunning}" -eq 1 ]; then
+    print_action "Uruchamiam ponownie kontener baserow"
+    docker start baserow >/dev/null
+fi
+
+if [ -f "${archivePath}" ]; then
+    file_size=$(stat -c %s "${archivePath}")
+    print_info "Rozmiar pliku backup: $(numfmt --to=iec ${file_size})"
+fi
+
+print_success "Backup Baserow zakończony pomyślnie!"

--- a/default-tools/baserow_backup
+++ b/default-tools/baserow_backup
@@ -1,8 +1,11 @@
 #!/bin/bash
 # Skrypt tworzy backup Baserow w środowisku Mikrusowym
 
-# ile ostatnich backupów trzymać?
-LASTBACKUPS=7
+# ile dni trzymać backupy?
+KEEPDAYS=7
+
+# poniżej tylu bajtów archiwum uznajemy za podejrzane i krzyczymy
+MINARCHIVEBYTES=10240
 
 # Kolory
 RED='\033[31m'
@@ -11,7 +14,7 @@ YELLOW='\033[33m'
 NC='\033[0m'
 
 CONFIG_DIR="/root/.baserow"
-BACKUP_DIR="/backup/baserow"
+CONFIG_FILE="${CONFIG_DIR}/mikrus.cfg"
 CRON_FILE="/etc/cron.d/baserow_backuper"
 
 print_error() {
@@ -35,6 +38,35 @@ if [ ! -d "${CONFIG_DIR}" ]; then
     exit 1
 fi
 
+# Skąd bierzemy dane?
+# baserow_install zapisuje DATA_DIR_PATH do pliku konfiguracyjnego. Starsze
+# instalacje go nie mają i trzymają dowiązanie /root/.baserow/data -> gdzieś indziej.
+# readlink -f rozwiązuje dowiązanie, bo tar bez tego zarchiwizowałby sam symlink
+# zamiast danych - archiwum ważyłoby kilkaset bajtów i nie zawierało niczego.
+if [ -f "${CONFIG_FILE}" ]; then
+    source "${CONFIG_FILE}"
+fi
+DATA_DIR="$(readlink -f "${DATA_DIR_PATH:-${CONFIG_DIR}/data}" 2>/dev/null)"
+
+if [ -z "${DATA_DIR}" ] || [ ! -d "${DATA_DIR}" ]; then
+    print_error "Nie znajduję katalogu danych Baserow (${DATA_DIR_PATH:-${CONFIG_DIR}/data})"
+    print_info "Sprawdź wpis DATA_DIR_PATH w ${CONFIG_FILE}"
+    exit 1
+fi
+
+# Gdzie odkładamy archiwa?
+# Na Mikrusie /storage to osobny, duży wolumen - dysk systemowy bywa ciasny,
+# a backupy Baserow potrafią ważyć setki megabajtów.
+if [ -n "${BACKUP_PATH:-}" ]; then
+    BACKUP_DIR="${BACKUP_PATH}"
+elif [ -d "/backup/baserow" ]; then
+    BACKUP_DIR="/backup/baserow"
+elif [ -d "/storage" ]; then
+    BACKUP_DIR="/storage/backup/baserow"
+else
+    BACKUP_DIR="/backup/baserow"
+fi
+
 if [ ! -d "${BACKUP_DIR}" ]; then
     print_action "Tworzę katalog ${BACKUP_DIR}/"
     mkdir -p "${BACKUP_DIR}"
@@ -45,17 +77,21 @@ if [ "$1" != "RUN" ]; then
     print_action "Konfiguruję automatyczny backup (godzina 4:${randomMinute})"
     echo "${randomMinute} 4 * * * root /bin/baserow_backup RUN >/dev/null 2>&1" > "${CRON_FILE}"
     print_success "Automatyczny skrypt backupu został aktywowany"
+    print_info "Backupy trafią do: ${BACKUP_DIR}/"
     exit 0
 fi
 
-find "${BACKUP_DIR}/" -name "*.tar.gz" -type f -mtime +${LASTBACKUPS} -delete
-
 currentDate=$(date +%Y%m%d)
 archivePath="${BACKUP_DIR}/${currentDate}_baserow.tar.gz"
+tmpPath="${archivePath}.tmp"
 wasRunning=0
 
 print_info "Rozpoczynam backup Baserow..."
 print_info "Data backupu: ${currentDate}"
+print_info "Katalog danych: ${DATA_DIR}"
+
+# sprzątamy po ewentualnym przerwanym poprzednim przebiegu
+rm -f "${tmpPath}"
 
 if docker ps --format '{{.Names}}' | grep -q '^baserow$'; then
     wasRunning=1
@@ -64,10 +100,23 @@ if docker ps --format '{{.Names}}' | grep -q '^baserow$'; then
 fi
 
 print_action "Tworzę archiwum ${archivePath}"
-if tar -czf "${archivePath}" -C /root .baserow; then
-    print_success "Backup Baserow został utworzony: ${archivePath}"
-else
+
+# Redis trzyma kolejkę zadań, nie dane użytkownika - nie ma po co go archiwizować.
+# Piszemy do pliku tymczasowego, żeby przerwany backup nie zostawił po sobie
+# uciętego archiwum wyglądającego jak poprawna kopia.
+tarStatus=0
+tar -czf "${tmpPath}" \
+    --exclude="$(basename "${DATA_DIR}")/redis" \
+    -C "$(dirname "${DATA_DIR}")" "$(basename "${DATA_DIR}")" || tarStatus=$?
+
+if [ ${tarStatus} -eq 0 ]; then
+    print_action "Weryfikuję integralność archiwum"
+    gzip -t "${tmpPath}" || tarStatus=$?
+fi
+
+if [ ${tarStatus} -ne 0 ]; then
     print_error "Nie udało się utworzyć backupu Baserow"
+    rm -f "${tmpPath}"
     if [ "${wasRunning}" -eq 1 ]; then
         print_action "Przywracam działanie kontenera baserow po błędzie backupu"
         docker start baserow >/dev/null
@@ -75,14 +124,31 @@ else
     exit 1
 fi
 
+mv "${tmpPath}" "${archivePath}"
+
+# konfiguracja obok archiwum - bez niej odtworzenie wymaga zgadywania portu i domeny
+if [ -f "${CONFIG_FILE}" ]; then
+    cp "${CONFIG_FILE}" "${BACKUP_DIR}/${currentDate}_mikrus.cfg"
+fi
+
 if [ "${wasRunning}" -eq 1 ]; then
     print_action "Uruchamiam ponownie kontener baserow"
     docker start baserow >/dev/null
 fi
 
-if [ -f "${archivePath}" ]; then
-    file_size=$(stat -c %s "${archivePath}")
-    print_info "Rozmiar pliku backup: $(numfmt --to=iec ${file_size})"
+file_size=$(stat -c %s "${archivePath}")
+print_info "Rozmiar pliku backup: $(numfmt --to=iec ${file_size})"
+
+if [ "${file_size}" -lt "${MINARCHIVEBYTES}" ]; then
+    print_error "Archiwum jest podejrzanie małe - prawdopodobnie nie zawiera danych!"
+    print_info "Sprawdź zawartość: tar -tzvf ${archivePath}"
+    exit 1
 fi
+
+# retencję czyścimy dopiero po udanym backupie - inaczej nieudany przebieg
+# najpierw kasuje stare kopie, a potem nie tworzy nowej
+find "${BACKUP_DIR}/" -name "*_baserow.tar.gz" -type f -mtime +${KEEPDAYS} -delete
+find "${BACKUP_DIR}/" -name "*_mikrus.cfg" -type f -mtime +${KEEPDAYS} -delete
+find "${BACKUP_DIR}/" -name "*.tar.gz.tmp" -type f -mtime +1 -delete
 
 print_success "Backup Baserow zakończony pomyślnie!"

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -31,6 +31,7 @@ if [ -f "${CONFIG_FILE}" ]; then
     saved_port="${PORT:-}"
     saved_domain="${DOMAIN:-}"
     saved_version="${BASEROW_VERSION:-}"
+    saved_image_ref="${BASEROW_IMAGE_REF:-}"
 fi
 
 # alternatywny numer portu
@@ -42,8 +43,8 @@ elif [ -n "${saved_port}" ]; then
     echo -e " ${GREEN}> Używam portu z pliku konfiguracyjnego: ${portNR}${NORMAL}"
 else
     portNR=$(hostname -f | grep -Eo '[0-9]+')
-    portNR=$((20000 + portNR))
-    echo -e " ${GREEN}> Używam domyślnego portu: ${portNR}${NORMAL}"
+    portNR=$((30000 + portNR))
+    echo -e " ${GREEN}> Używam domyślnego portu Mikrusa dla usług: ${portNR}${NORMAL}"
 fi
 
 # mamy dockera?
@@ -72,21 +73,26 @@ echo -e " ${GREEN}> Ustalam wersję Baserow${NORMAL}"
 docker pull baserow/baserow:latest
 
 baserowVersion=$(docker image inspect baserow/baserow:latest --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' 2>/dev/null)
+baserowImageRef=$(docker image inspect baserow/baserow:latest --format '{{ index .RepoDigests 0 }}' 2>/dev/null)
 
 if [ -z "${baserowVersion}" ] || [ "${baserowVersion}" = "<no value>" ]; then
-    if [ -n "${saved_version}" ]; then
-        baserowVersion="${saved_version}"
-        echo -e " ${YELLOW}> Nie udało się odczytać wersji latest - używam zapisanej wersji: ${baserowVersion}${NORMAL}"
+    if [ -n "${baserowImageRef}" ] && [ "${baserowImageRef}" != "<no value>" ]; then
+        baserowVersion="latest"
+        echo -e " ${YELLOW}> Obraz nie podaje wersji semantycznej - przypinam instalację po digest${NORMAL}"
+    elif [ -n "${saved_image_ref}" ]; then
+        baserowImageRef="${saved_image_ref}"
+        baserowVersion="${saved_version:-latest}"
+        echo -e " ${YELLOW}> Nie udało się odczytać danych latest - używam zapisanej referencji obrazu${NORMAL}"
     else
-        echo -e " ${RED}> Nie udało się ustalić konkretnej wersji obrazu Baserow${NORMAL}"
+        echo -e " ${RED}> Nie udało się ustalić referencji obrazu Baserow${NORMAL}"
         exit 2
     fi
 else
     echo -e " ${GREEN}> Aktualna wersja latest to: ${baserowVersion}${NORMAL}"
 fi
 
-if [ "${baserowVersion}" != "latest" ]; then
-    docker pull "baserow/baserow:${baserowVersion}"
+if [ -z "${baserowImageRef}" ] || [ "${baserowImageRef}" = "<no value>" ]; then
+    baserowImageRef="baserow/baserow:${baserowVersion}"
 fi
 
 # wsparcie dla alternatywnej domeny
@@ -107,6 +113,7 @@ cat > "${CONFIG_FILE}" << EOF
 PORT=${portNR}
 DOMAIN=${domain}
 BASEROW_VERSION=${baserowVersion}
+BASEROW_IMAGE_REF=${baserowImageRef}
 EOF
 
 echo -e " ${GREEN}> Uruchamiam kontener...${NORMAL}"
@@ -123,7 +130,7 @@ docker run -itd \
   -v ${DATA_DIR}:/baserow/data \
   --restart unless-stopped \
   -e BASEROW_PUBLIC_URL=https://${domain} \
-  baserow/baserow:${baserowVersion}
+  ${baserowImageRef}
 
 echo -n -e " ${GREEN}> Startowanie aplikacji...${NORMAL}"
 

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -129,7 +129,7 @@ docker run -itd \
   -p ${portNR}:80 \
   -v ${DATA_DIR}:/baserow/data \
   --restart unless-stopped \
-  -e BASEROW_PUBLIC_URL=http://${domain} \
+  -e BASEROW_PUBLIC_URL=https://${domain} \
   ${baserowImageRef}
 
 echo -n -e " ${GREEN}> Startowanie aplikacji...${NORMAL}"
@@ -161,4 +161,4 @@ while true; do
 done
 
 echo -e "\n\n${GREEN}Twoja instancja Baserow jest pod adresem:${NORMAL}\n"
-echo -e "http://${domain}\n\n"
+echo -e "https://${domain}\n\n"

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -137,7 +137,9 @@ echo -n -e " ${GREEN}> Startowanie aplikacji...${NORMAL}"
 cnt=120
 
 while true; do
-  if curl -fsS --max-time 5 "http://127.0.0.1:${portNR}" >/dev/null 2>&1; then
+  http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${portNR}" 2>/dev/null || true)
+
+  if [ -n "${http_code}" ] && [ "${http_code}" != "000" ]; then
     break
   fi
 

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -160,5 +160,10 @@ while true; do
   cnt=$((cnt - 1))
 done
 
+# aktywujemy backup dla usera
+/bin/baserow_backup
+
 echo -e "\n\n${GREEN}Twoja instancja Baserow jest pod adresem:${NORMAL}\n"
 echo -e "https://${domain}\n\n"
+
+echo -e "\n${NORMAL}Gdy będziesz chciał zaktualizować swoją instancję użyj ${YELLOW}baserow_update${NORMAL}\n\n"

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -1,0 +1,160 @@
+#!/bin/bash
+#
+# Skrypt instalujący aplikację Baserow
+# Dostosowany do użycia w środowisku Mikrusa - https://mikr.us
+#
+
+MINIMALRAM=2000
+
+# kolorki
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NORMAL='\033[0m'
+
+availableMemory=$(free -m | awk '/^Mem:/ {print $2}')
+
+if [ "${availableMemory}" -gt "${MINIMALRAM}" ]; then
+    echo -e "${GREEN}System ma ponad ${MINIMALRAM}MB pamięci RAM${NORMAL}"
+else
+    echo -e "${RED}System ma mniej niż ${MINIMALRAM}MB pamięci RAM - to nie zadziała...${NORMAL}"
+    exit 2
+fi
+
+# wczytanie konfiguracji z pliku (jeśli istnieje)
+CONFIG_DIR="/root/.baserow"
+DATA_DIR="${CONFIG_DIR}/data"
+CONFIG_FILE="${CONFIG_DIR}/mikrus.cfg"
+if [ -f "${CONFIG_FILE}" ]; then
+    echo -e " ${GREEN}> Wczytuję konfigurację z pliku${NORMAL}"
+    source "${CONFIG_FILE}"
+    saved_port="${PORT:-}"
+    saved_domain="${DOMAIN:-}"
+    saved_version="${BASEROW_VERSION:-}"
+fi
+
+# alternatywny numer portu
+if [ -n "$1" ] && [[ "$1" =~ ^[0-9]+$ ]]; then
+    portNR=$1
+    echo -e " ${GREEN}> Używam podanego portu: ${portNR}${NORMAL}"
+elif [ -n "${saved_port}" ]; then
+    portNR="${saved_port}"
+    echo -e " ${GREEN}> Używam portu z pliku konfiguracyjnego: ${portNR}${NORMAL}"
+else
+    portNR=$(hostname -f | grep -Eo '[0-9]+')
+    portNR=$((20000 + portNR))
+    echo -e " ${GREEN}> Używam domyślnego portu: ${portNR}${NORMAL}"
+fi
+
+# mamy dockera?
+if command -v docker &> /dev/null; then
+    echo -e " ${GREEN}> Docker jest zainstalowany${NORMAL}"
+else
+    echo -e " ${YELLOW}> Instaluję Dockera${NORMAL}"
+    curl -fsSL https://get.docker.com | sh -
+fi
+
+if [ ! -d "${CONFIG_DIR}" ]; then
+    echo -e " ${YELLOW}> Tworzę katalog domowy dla Baserow${NORMAL}"
+    mkdir -p "${CONFIG_DIR}"
+else
+    echo -e " ${GREEN}> Katalog domowy już istnieje - użyję go${NORMAL}"
+fi
+
+if [ ! -d "${DATA_DIR}" ]; then
+    echo -e " ${YELLOW}> Tworzę katalog na dane Baserow${NORMAL}"
+    mkdir -p "${DATA_DIR}"
+else
+    echo -e " ${GREEN}> Katalog na dane już istnieje - użyję go${NORMAL}"
+fi
+
+echo -e " ${GREEN}> Ustalam wersję Baserow${NORMAL}"
+docker pull baserow/baserow:latest
+
+baserowVersion=$(docker image inspect baserow/baserow:latest --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' 2>/dev/null)
+
+if [ -z "${baserowVersion}" ] || [ "${baserowVersion}" = "<no value>" ]; then
+    if [ -n "${saved_version}" ]; then
+        baserowVersion="${saved_version}"
+        echo -e " ${YELLOW}> Nie udało się odczytać wersji latest - używam zapisanej wersji: ${baserowVersion}${NORMAL}"
+    else
+        echo -e " ${RED}> Nie udało się ustalić konkretnej wersji obrazu Baserow${NORMAL}"
+        exit 2
+    fi
+else
+    echo -e " ${GREEN}> Aktualna wersja latest to: ${baserowVersion}${NORMAL}"
+fi
+
+if [ "${baserowVersion}" != "latest" ]; then
+    docker pull "baserow/baserow:${baserowVersion}"
+fi
+
+# wsparcie dla alternatywnej domeny
+if [ -n "$2" ] && [[ "$2" =~ ^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+    domain="$2"
+    echo -e " ${GREEN}> Używam podanej domeny: ${domain}${NORMAL}"
+elif [ -n "${saved_domain}" ] && [ -z "${1:-}" ] && [ -z "${2:-}" ]; then
+    domain="${saved_domain}"
+    echo -e " ${GREEN}> Używam domeny z pliku konfiguracyjnego: ${domain}${NORMAL}"
+else
+    eval "$(curl -s -k -6 https://info.mikr.us)"
+    domain="${info_imie_id}-${portNR}.wykr.es"
+    echo -e " ${GREEN}> Używam domyślnej domeny: ${domain}${NORMAL}"
+fi
+
+echo -e " ${GREEN}> Zapisuję konfigurację do pliku${NORMAL}"
+cat > "${CONFIG_FILE}" << EOF
+PORT=${portNR}
+DOMAIN=${domain}
+BASEROW_VERSION=${baserowVersion}
+EOF
+
+echo -e " ${GREEN}> Uruchamiam kontener...${NORMAL}"
+
+# porządki
+docker rm -f baserow >/dev/null 2>&1
+
+docker run -itd \
+  --memory=$((availableMemory - 100))m \
+  --memory-swap=$((availableMemory - 100))m \
+  --memory-swappiness=0 \
+  --name baserow \
+  -p ${portNR}:80 \
+  -v ${DATA_DIR}:/baserow/data \
+  --restart unless-stopped \
+  -e BASEROW_PUBLIC_URL=https://${domain} \
+  baserow/baserow:${baserowVersion}
+
+echo -n -e " ${GREEN}> Startowanie aplikacji...${NORMAL}"
+
+cnt=36
+
+while true; do
+  log_ready=0
+  http_ready=0
+
+  if docker logs baserow 2>&1 | grep -q "Baserow is now available at"; then
+    log_ready=1
+  fi
+
+  if curl -fsS --max-time 5 "http://127.0.0.1:${portNR}" >/dev/null 2>&1; then
+    http_ready=1
+  fi
+
+  if [ "${log_ready}" -eq 1 ] && [ "${http_ready}" -eq 1 ]; then
+    break
+  fi
+
+  if [ ${cnt} -eq 0 ]; then
+    echo -e "${RED}Coś nie działa :(${NORMAL}"
+    echo -e "${YELLOW}Sprawdź logi poleceniem: docker logs baserow${NORMAL}"
+    exit 2
+  fi
+
+  echo -n "."
+  sleep 5
+  cnt=$((cnt - 1))
+done
+
+echo -e "\n\n${GREEN}Twoja instancja Baserow jest pod adresem:${NORMAL}\n"
+echo -e "https://${domain}\n\n"

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -23,7 +23,6 @@ fi
 
 # wczytanie konfiguracji z pliku (jeśli istnieje)
 CONFIG_DIR="/root/.baserow"
-DATA_DIR="${CONFIG_DIR}/data"
 CONFIG_FILE="${CONFIG_DIR}/mikrus.cfg"
 if [ -f "${CONFIG_FILE}" ]; then
     echo -e " ${GREEN}> Wczytuję konfigurację z pliku${NORMAL}"
@@ -32,7 +31,36 @@ if [ -f "${CONFIG_FILE}" ]; then
     saved_domain="${DOMAIN:-}"
     saved_version="${BASEROW_VERSION:-}"
     saved_image_ref="${BASEROW_IMAGE_REF:-}"
+    saved_data_dir="${DATA_DIR_PATH:-}"
+    saved_memory="${MEMORY_LIMIT:-}"
+    saved_minimal="${RUN_MINIMAL:-}"
+    saved_backup_path="${BACKUP_PATH:-}"
 fi
+
+# Gdzie trzymamy dane?
+# Mikrus daje dodatkową przestrzeń w /storage, a dysk systemowy bywa ciasny.
+# Istniejące instalacje zostają tam, gdzie już są - kolejność warunków to gwarantuje.
+if [ -n "${saved_data_dir}" ]; then
+    DATA_DIR="${saved_data_dir}"
+elif [ -d "${CONFIG_DIR}/data" ]; then
+    DATA_DIR="${CONFIG_DIR}/data"
+elif [ -d "/storage" ]; then
+    DATA_DIR="/storage/baserow"
+else
+    DATA_DIR="${CONFIG_DIR}/data"
+fi
+
+# Tryb oszczędny - domyślnie włączony.
+# Bez tego Baserow uruchamia osobny worker eksportu i wiele procesów gunicorn.
+# Na małej maszynie kosztuje to grubo ponad 800MB RAM ponad realną potrzebę.
+# Wyłącz ustawiając RUN_MINIMAL=no w pliku konfiguracyjnym.
+runMinimal="${saved_minimal:-yes}"
+
+# Twardy limit pamięci kontenera w MB.
+# Puste = cała pamięć maszyny minus 100MB (zachowanie domyślne).
+# Jeśli dzielisz Mikrusa z innymi usługami, ustaw MEMORY_LIMIT=2048
+# w pliku konfiguracyjnym - inaczej Baserow pod obciążeniem wypcha resztę.
+memoryLimit="${saved_memory:-}"
 
 # alternatywny numer portu
 if [ -n "$1" ] && [[ "$1" =~ ^[0-9]+$ ]]; then
@@ -63,10 +91,10 @@ else
 fi
 
 if [ ! -d "${DATA_DIR}" ]; then
-    echo -e " ${YELLOW}> Tworzę katalog na dane Baserow${NORMAL}"
+    echo -e " ${YELLOW}> Tworzę katalog na dane Baserow: ${DATA_DIR}${NORMAL}"
     mkdir -p "${DATA_DIR}"
 else
-    echo -e " ${GREEN}> Katalog na dane już istnieje - użyję go${NORMAL}"
+    echo -e " ${GREEN}> Katalog na dane już istnieje - użyję go: ${DATA_DIR}${NORMAL}"
 fi
 
 echo -e " ${GREEN}> Ustalam wersję Baserow${NORMAL}"
@@ -114,23 +142,48 @@ PORT=${portNR}
 DOMAIN=${domain}
 BASEROW_VERSION=${baserowVersion}
 BASEROW_IMAGE_REF=${baserowImageRef}
+DATA_DIR_PATH=${DATA_DIR}
+MEMORY_LIMIT=${memoryLimit}
+RUN_MINIMAL=${runMinimal}
+BACKUP_PATH=${saved_backup_path}
 EOF
+
+# budujemy parametry uruchomienia
+runArgs=(
+    -itd
+    --name baserow
+    -p "${portNR}:80"
+    -v "${DATA_DIR}:/baserow/data"
+    --restart unless-stopped
+    -e "BASEROW_PUBLIC_URL=https://${domain}"
+)
+
+if [ -n "${memoryLimit}" ]; then
+    echo -e " ${GREEN}> Limit pamięci kontenera: ${memoryLimit}MB${NORMAL}"
+    runArgs+=( --memory="${memoryLimit}m" --memory-swap="${memoryLimit}m" --memory-swappiness=0 )
+else
+    echo -e " ${YELLOW}> Limit pamięci kontenera: $((availableMemory - 100))MB (cała maszyna)${NORMAL}"
+    echo -e " ${YELLOW}  Dzielisz Mikrusa z innymi usługami? Ustaw MEMORY_LIMIT w ${CONFIG_FILE}${NORMAL}"
+    runArgs+=( --memory="$((availableMemory - 100))m" --memory-swap="$((availableMemory - 100))m" --memory-swappiness=0 )
+fi
+
+if [ "${runMinimal}" != "no" ]; then
+    echo -e " ${GREEN}> Tryb oszczędzania RAM: włączony${NORMAL}"
+    runArgs+=(
+        -e BASEROW_AMOUNT_OF_WORKERS=1
+        -e BASEROW_AMOUNT_OF_GUNICORN_WORKERS=1
+        -e BASEROW_RUN_MINIMAL=yes
+    )
+else
+    echo -e " ${YELLOW}> Tryb oszczędzania RAM: wyłączony (RUN_MINIMAL=no)${NORMAL}"
+fi
 
 echo -e " ${GREEN}> Uruchamiam kontener...${NORMAL}"
 
 # porządki
 docker rm -f baserow >/dev/null 2>&1
 
-docker run -itd \
-  --memory=$((availableMemory - 100))m \
-  --memory-swap=$((availableMemory - 100))m \
-  --memory-swappiness=0 \
-  --name baserow \
-  -p ${portNR}:80 \
-  -v ${DATA_DIR}:/baserow/data \
-  --restart unless-stopped \
-  -e BASEROW_PUBLIC_URL=https://${domain} \
-  ${baserowImageRef}
+docker run "${runArgs[@]}" "${baserowImageRef}"
 
 echo -n -e " ${GREEN}> Startowanie aplikacji...${NORMAL}"
 
@@ -161,7 +214,7 @@ while true; do
 done
 
 # aktywujemy backup dla usera
-/bin/baserow_backup
+"$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/baserow_backup"
 
 echo -e "\n\n${GREEN}Twoja instancja Baserow jest pod adresem:${NORMAL}\n"
 echo -e "https://${domain}\n\n"

--- a/default-tools/baserow_install
+++ b/default-tools/baserow_install
@@ -129,27 +129,22 @@ docker run -itd \
   -p ${portNR}:80 \
   -v ${DATA_DIR}:/baserow/data \
   --restart unless-stopped \
-  -e BASEROW_PUBLIC_URL=https://${domain} \
+  -e BASEROW_PUBLIC_URL=http://${domain} \
   ${baserowImageRef}
 
 echo -n -e " ${GREEN}> Startowanie aplikacji...${NORMAL}"
 
-cnt=36
+cnt=120
 
 while true; do
-  log_ready=0
-  http_ready=0
-
-  if docker logs baserow 2>&1 | grep -q "Baserow is now available at"; then
-    log_ready=1
-  fi
-
   if curl -fsS --max-time 5 "http://127.0.0.1:${portNR}" >/dev/null 2>&1; then
-    http_ready=1
+    break
   fi
 
-  if [ "${log_ready}" -eq 1 ] && [ "${http_ready}" -eq 1 ]; then
-    break
+  if ! docker ps --format '{{.Names}}' | grep -q '^baserow$'; then
+    echo -e "${RED}Kontener baserow zakończył pracę podczas startu${NORMAL}"
+    echo -e "${YELLOW}Sprawdź logi poleceniem: docker logs baserow${NORMAL}"
+    exit 2
   fi
 
   if [ ${cnt} -eq 0 ]; then
@@ -164,4 +159,4 @@ while true; do
 done
 
 echo -e "\n\n${GREEN}Twoja instancja Baserow jest pod adresem:${NORMAL}\n"
-echo -e "https://${domain}\n\n"
+echo -e "http://${domain}\n\n"

--- a/default-tools/baserow_update
+++ b/default-tools/baserow_update
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! -d /root/.baserow ]; then
+    echo "Baserow nie jest zainstalowany. Użyj najpierw baserow_install."
+    exit 1
+fi
+
+echo "Tworzę backup przed aktualizacją..."
+/bin/baserow_backup RUN || exit 1
+
+echo "Pobieram najnowszy obraz i odtwarzam kontener..."
+baserow_install

--- a/default-tools/baserow_update
+++ b/default-tools/baserow_update
@@ -5,8 +5,12 @@ if [ ! -d /root/.baserow ]; then
     exit 1
 fi
 
+# Narzędzia wołamy z katalogu, w którym leży ten skrypt. Dzięki temu działa
+# zarówno po instalacji w /bin, jak i uruchomione wprost z repozytorium.
+TOOLS_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
 echo "Tworzę backup przed aktualizacją..."
-/bin/baserow_backup RUN || exit 1
+"${TOOLS_DIR}/baserow_backup" RUN || exit 1
 
 echo "Pobieram najnowszy obraz i odtwarzam kontener..."
-/bin/baserow_install
+"${TOOLS_DIR}/baserow_install"

--- a/default-tools/baserow_update
+++ b/default-tools/baserow_update
@@ -9,4 +9,4 @@ echo "Tworzę backup przed aktualizacją..."
 /bin/baserow_backup RUN || exit 1
 
 echo "Pobieram najnowszy obraz i odtwarzam kontener..."
-baserow_install
+/bin/baserow_install


### PR DESCRIPTION
  Ten PR dodaje obsługę Baserow do default-tools, w stylu zbliżonym do istniejących narzędzi dla n8n, ale dostosowaną do tego, jak Baserow działa oficjalnie w Dockerze.

  Zakres zmian

  Dodane zostały nowe komendy:

  - baserow_install
  - baserow_backup
  - baserow_update

  Szczegóły implementacji

  - baserow_install uruchamia Baserow na bazie oficjalnego obrazu baserow/baserow w wariancie single-container
  - trwałe dane są przechowywane w /root/.baserow/data
  - konfiguracja instalatora jest trzymana osobno w /root/.baserow/mikrus.cfg
  - instalator zapisuje:
      - PORT
      - DOMAIN
      - BASEROW_VERSION
      - BASEROW_IMAGE_REF
  - jeśli obraz nie udostępnia wersji semantycznej w labelach, instalacja przypina obraz po digest
  - logika wyboru portu została dopasowana do realiów Mikrusa:
      - port podany jako argument, jeśli został przekazany
      - port zapisany w configu, jeśli istnieje
      - w przeciwnym razie domyślnie 30000 + ID maszyny
  - BASEROW_PUBLIC_URL ustawiane jest na publiczny adres https://...wykr.es
  - sprawdzanie gotowości aplikacji zostało oparte na rzeczywistej odpowiedzi HTTP po localhost, zamiast na kruchym dopasowaniu pojedynczego komunikatu z logów

  Backup i update

  - baserow_backup
      - bez argumentów konfiguruje cron
      - tworzy backup do /backup/baserow
      - archiwizuje cały katalog /root/.baserow
      - na czas backupu tymczasowo zatrzymuje kontener baserow, a potem uruchamia go ponownie, żeby zachować spójność danych
  - baserow_update
      - najpierw wykonuje backup
      - następnie uruchamia ponownie baserow_install, co pobiera najnowszy obraz i odtwarza kontener na tych samych danych

  Dlaczego tak

  Chciałem zachować UX podobny do istniejących komend n8n, ale nie kopiować ich architektury 1:1.
  Baserow oficjalnie wspiera wariant single-container z wbudowanym PostgreSQL i Redis, więc pierwszy wariant wdrożony w tym PR opiera się właśnie na tym modelu.

  Testy

  Zmiany były testowane na realnym serwerze Mikrus.
  W trakcie testów zostały dopracowane:

  - wykrywanie wersji obrazu
  - domyślny wybór portu
  - publiczny URL
  - warunek uznania aplikacji za gotową

  Ten PR obejmuje pierwszy wariant Baserow.
  Obsługa zewnętrznego PostgreSQL i Valkey może zostać dodana później jako osobny kolejny krok.