### PR TITLE
Naprawa chce_ftp.sh. Poprawa listen_port na numeryczny. Poprawny zapis do vsftpd.conf.

### DIFF
--- a/scripts/chce_ftp.sh
+++ b/scripts/chce_ftp.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # FTP installation script
 # Authors: Mariusz 'maniek205' Kowalski
+# Edycja: pZ: Paweł 'pauluZ' Szczepanek
 
 err() {
     echo -e "\e[0;31m[!] \e[1;31m$1\e[0;0m";
@@ -11,25 +12,33 @@ err() {
 sudo --validate || { err "Nie masz uprawnien do uruchamiania komend jako root - dodaj '$USER' do grupy 'sudoers'."; }
 
 hostname=$(hostname)
-listen_port=20${hostname:1}
+# pZ: Jesli serwer ma nazwe 'xxxxxxx123' (cyfry na koncu moga byc dowolne) to pobieram trzy ostatnie cyfry
+listen_port=20${hostname:(-3)}
+listen_port30=30${hostname:(-3)}
+vsftpd_conf=/etc/vsftpd.conf
 
-if sudo lsof -i:"${listen_port}" | grep -q PID ; then
-   echo "$listen_port in use trying: "
-   listen_port=30${hostname:1}
-   echo "$listen_port"
-elif sudo lsof -i:"${listen_port}" | grep -q PID ; then
-   echo "$listen_port in use error. All external ports are in use. Please release external port 20${hostname:1} or 30${hostname:1}"
-   exit 1
+if (sudo lsof -i:"${listen_port}" | grep -q PID) ; then
+    echo "Port $listen_port in use trying: $listen_port30"
+    if (sudo lsof -i:"${listen_port30}" | grep -q PID) ; then
+        err "Port $listen_port30 in use error. All external ports are in use. Please release external port $listen_port or $listen_port30."
+        exit 1
+    else
+        listen_port=${listen_port30}
+    fi
 fi
 echo "Using port: $listen_port"
 
 sudo apt update
 sudo apt install -y vsftpd
-sudo sed -i 's/#write_enable=YES/write_enable=YES/g' /etc/vsftpd.conf
 
-echo "
-listen_port=${listen_port}
-" >> /etc/vsftpd.conf
+sudo sed -i 's/#write_enable=YES/write_enable=YES/g' ${vsftpd_conf}
+
+# pZ: podmiana lub dodanie linii 'listen_port=xxx' do /etc/vsftpd.conf (echo nie dziala dla sudo)
+if (grep -q "^listen_port=.*" ${vsftpd_conf}) ; then
+    sudo sed -i 's/^listen_port=.*/listen_port='"$listen_port"'/g' ${vsftpd_conf}
+else
+    sudo sed -i '$s/$/\nlisten_port='"$listen_port"'/' ${vsftpd_conf}
+fi
 
 sudo systemctl enable vsftpd
 sudo systemctl restart vsftpd
@@ -37,3 +46,11 @@ sudo systemctl restart vsftpd
 echo "FTP server has been installed. Use your credentials to log in.
 Server IP: srvX.mikr.us (change X to your server number)
 Port: $listen_port"
+
+# pZ: sprawdzenie co nasluchuje na roznych portach:
+# /usr/bin/ss -tuln
+# -t, --tcp           display only TCP sockets
+# -u, --udp           display only UDP sockets
+# -l, --listening     display listening sockets
+# -n, --numeric       don't resolve service names (aby nie zamienial portow na uslugi np. :22 na ssh)
+# EOF


### PR DESCRIPTION
Jeśli serwer ma nazwę '_xxxxxxx123_' (cyfry na końcu mogą być dowolne) to pobieram **trzy** ostatnie cyfry do określenia portu.
Podmiana lub dodanie linii '_listen_port=xxx_' do `/etc/vsftpd.conf` (ponieważ samo `echo` nie skutkuje a użycie `sudo echo` nie działa)
Ponadto staram się rozwiązać problem jeśli linia '_listen_port=xxx_' **już istniałaby** odkomentowana.